### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/CONTRIBUTING.Rmd
+++ b/CONTRIBUTING.Rmd
@@ -122,7 +122,7 @@ data may be provided in any way that is convenient including
 posting to a website, on [figshare](http://figshare.com/), a public
 Dropbox link, a [GitHub gist](https://gist.github.com), or even
 included in the pull request (PR). Once the PR is ready to merge the data should
-be placed in the [official data repository](https://dx.doi.org/10.6084/m9.figshare.1314459.v5)
+be placed in the [official data repository](https://doi.org/10.6084/m9.figshare.1314459.v5)
 and all links to the data updated.
 
 ## Formatting of the material

--- a/CONTRIBUTING.html
+++ b/CONTRIBUTING.html
@@ -400,7 +400,7 @@ div.tocify {
 </div>
 <div id="datasets" class="section level2">
 <h2>Datasets</h2>
-<p>We don’t store data for lessons inside the lesson repositories. For completed lessons the data should be publicly available in a data repository appropriate to the data type. For lesson development the data may be provided in any way that is convenient including posting to a website, on <a href="http://figshare.com/">figshare</a>, a public Dropbox link, a <a href="https://gist.github.com">GitHub gist</a>, or even included in the pull request (PR). Once the PR is ready to merge the data should be placed in the <a href="https://dx.doi.org/10.6084/m9.figshare.1314459.v5">official data repository</a> and all links to the data updated.</p>
+<p>We don’t store data for lessons inside the lesson repositories. For completed lessons the data should be publicly available in a data repository appropriate to the data type. For lesson development the data may be provided in any way that is convenient including posting to a website, on <a href="http://figshare.com/">figshare</a>, a public Dropbox link, a <a href="https://gist.github.com">GitHub gist</a>, or even included in the pull request (PR). Once the PR is ready to merge the data should be placed in the <a href="https://doi.org/10.6084/m9.figshare.1314459.v5">official data repository</a> and all links to the data updated.</p>
 </div>
 <div id="formatting-of-the-material" class="section level2">
 <h2>Formatting of the material</h2>


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!